### PR TITLE
Feature/ond211 2330 develop rag flow backend integration

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,7 +5,7 @@ grpcio>=1.67.1,<1.68.0
 grpcio-reflection>=1.67.1,<1.68.0
 grpcio-status>=1.67.1,<1.68.0
 grpcio-tools>=1.67.1,<1.68.0
-mypy-protobuf>=3.6.0
+mypy-protobuf==3.6.0
 protobuf==5.27.5
 python-protobuf
 types-protobuf>=5.28


### PR DESCRIPTION
Pin mypy-protobuf version to 3.6.0 because the newest version is incompatible with protobuf version 5.27.5